### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gustavotaques/todolist/security/code-scanning/1](https://github.com/gustavotaques/todolist/security/code-scanning/1)

To fix the issue, you need to add a `permissions` key at the root level of the workflow, before defining `jobs:`. This ensures jobs run with only the specified minimal permissions. For read-only scanning jobs like FOSSA, only `contents: read` is typically needed, which limits GITHUB_TOKEN to only read repository contents. No other permission types are necessary, unless future steps explicitly require them. You can safely add this block immediately after the workflow `name:` and `on:` keys in `.github/workflows/fossa.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
